### PR TITLE
feat(user delete): make appropriate client-api request from events queue

### DIFF
--- a/sqs_lambda/config.ts
+++ b/sqs_lambda/config.ts
@@ -1,11 +1,17 @@
+const environment = process.env.ENVIRONMENT || 'development';
+const isDev = environment === 'development';
+
 const config = {
-  environment: process.env.ENVIRONMENT || 'development',
+  environment: environment,
   sentry: {
     // these values are inserted into the environment in
     // .aws/src/sqsLambda.ts
     dsn: process.env.SENTRY_DSN || '',
     release: process.env.GIT_SHA || '',
   },
+  clientApiUri: isDev
+    ? process.env.CLIENT_API_URI || 'https://client-api.getpocket.dev'
+    : process.env.CLIENT_API_URI || 'https://client-api.readitlater.com',
 };
 
 export default config;

--- a/sqs_lambda/index.spec.ts
+++ b/sqs_lambda/index.spec.ts
@@ -1,0 +1,41 @@
+import * as fx from './index';
+import config from './config';
+import nock from 'nock';
+
+describe('SQS Event Handler', () => {
+  afterAll(() => {
+    nock.restore();
+  });
+  it('sends a user delete event to client-api', async () => {
+    const scope = nock(config.clientApiUri)
+      .post('/')
+      .reply(200, { data: { deleteUserByFxaId: '12345' } });
+    await fx.handlerFn({
+      Records: [
+        { user_id: '12345', event: fx.EVENT.USER_DELETE, timestamp: 12345 },
+      ],
+    });
+    // Nock marks as done if a request was successfully intercepted
+    expect(scope.isDone()).toBeTruthy();
+  });
+  it('throws an error if error data is returned from client-api', async () => {
+    const replyData = { data: null, errors: { CODE: 'FORBIDDEN' } };
+    const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
+    const record = {
+      user_id: '12345',
+      event: fx.EVENT.USER_DELETE,
+      timestamp: 12345,
+    };
+    await expect(async () => {
+      await fx.handlerFn({
+        Records: [record],
+      });
+    }).rejects.toThrow(
+      `Error processing ${JSON.stringify(record)}: \n${JSON.stringify(
+        replyData.errors
+      )}`
+    );
+    // Nock marks as done if a request was successfully intercepted
+    expect(scope.isDone()).toBeTruthy();
+  });
+});

--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -1,12 +1,68 @@
 import * as Sentry from '@sentry/serverless';
 import config from './config';
+import fetch from 'node-fetch';
+
+// Not DRY -- try lambda layers?
+export enum EVENT {
+  USER_DELETE = 'user_delete',
+  PROFILE_UPDATE = 'profile_update',
+}
+
+type SqsEvent = {
+  user_id: string;
+  event: EVENT;
+  timestamp: number;
+};
+
+/**
+ * Submit deleteUserByFxaId mutation POST request to client-api
+ * @param id FxA account ID to delete from Pocket's database
+ */
+async function submitDeleteMutation(id: string): Promise<any> {
+  const deleteMutation = `
+mutation deleteUser($id: ID!) {
+  deleteUserByFxaId(id: $id)
+}`;
+  const variables = { id: id };
+  return await fetch(config.clientApiUri, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // TODO: INFRA-169
+      // Authorization: jwt,
+    },
+    body: JSON.stringify({ query: deleteMutation, variables }),
+  }).then((response) => response.json());
+}
+
+/**
+ * Lambda handler function. Separated from the Sentry wrapper
+ * to make unit-testing easier.
+ * Takes records from SQS queue with events, and makes
+ * the appropriate request against client-api.
+ * TODO: Authorization bearer - INFRA-169
+ */
+export async function handlerFn(event: { Records: SqsEvent[] }) {
+  await Promise.all(
+    event.Records.map(async (record: SqsEvent) => {
+      if (record.event === EVENT.USER_DELETE) {
+        const res = await submitDeleteMutation(record.user_id);
+        if (res?.errors) {
+          throw new Error(
+            `Error processing ${JSON.stringify(record)}: \n${JSON.stringify(
+              res?.errors
+            )}`
+          );
+        }
+      }
+    })
+  );
+  return {};
+}
 
 Sentry.AWSLambda.init({
   dsn: config.sentry.dsn,
   release: config.sentry.release,
   environment: config.environment,
 });
-
-export const handler = Sentry.AWSLambda.wrapHandler(async (event: any) => {
-  console.log('I will handle it');
-});
+export const handler = Sentry.AWSLambda.wrapHandler(handlerFn);

--- a/sqs_lambda/package-lock.json
+++ b/sqs_lambda/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.41.0",
-        "@sentry/serverless": "^6.14.3"
+        "@sentry/serverless": "^6.15.0",
+        "node-fetch": "^2.6.6"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.85",
@@ -862,14 +863,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.3.tgz",
-      "integrity": "sha512-3yHmYZzkXlOqPi/CGlNhb2RzXFvYAryBhrMJV26KJ9ULJF8r4OJ7TcWlupDooGk6Knmq8GQML58OApUvYi8IKg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "dependencies": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/minimal": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -882,12 +883,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/hub": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.3.tgz",
-      "integrity": "sha512-ZRWLHcAcv4oZAbpSwvCkXlaa1rVFDxcb9lxo5/5v5n6qJq2IG5Z+bXuT2DZlIHQmuCuqRnFSwuBjmBXY7OTHaw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "dependencies": {
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -900,12 +901,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.3.tgz",
-      "integrity": "sha512-2KNOJuhBpMICoOgdxX56UcO9vGdxCw5mNGYdWvJdKrMwRQr7mC+Fc9lTuTbrYTj6zkfklj2lbdDc3j44Rg787A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "dependencies": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/types": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -918,15 +919,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/node": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.3.tgz",
-      "integrity": "sha512-b7NjMdqpDOTxV0hiR90jlK52i9cTdAJgGjQykGFyBDf7rTGDohyEYsERgJ5+/VC3Inan/P3m12PctWA/TMwZCw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "dependencies": {
-        "@sentry/core": "6.14.3",
-        "@sentry/hub": "6.14.3",
-        "@sentry/tracing": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -942,15 +943,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/serverless": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.14.3.tgz",
-      "integrity": "sha512-RFksAbOiiaaB0n+7mpxQ1MEji1iqmoAxnNS9mNVkyfls6W5iZ9PoNdtkGFFewYaIAhOrAtWTz9sI5NogTk6YVQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.15.0.tgz",
+      "integrity": "sha512-FAIS9H5YLxjhn7deLdEJ6lwoGfDpUMbbHP4+9pHe0vIqJ7q7hX4/pjb9IQUu/Hwh62kRI4ORXsmj9KvxAlqmkg==",
       "dependencies": {
-        "@sentry/minimal": "6.14.3",
-        "@sentry/node": "6.14.3",
-        "@sentry/tracing": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/node": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "@types/aws-lambda": "^8.10.62",
         "@types/express": "^4.17.2",
         "tslib": "^1.9.3"
@@ -965,14 +966,14 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/tracing": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.3.tgz",
-      "integrity": "sha512-laFayAxpO/dQL3K3ZcSjtaqJkSf70DH1hHJ8Oiiic0c/xBxh38WSx8yu3TMrbfka5MVIuMNlkq1Gi+SC+moe4w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "dependencies": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/minimal": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -985,19 +986,19 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.3.tgz",
-      "integrity": "sha512-GuyqvjQ/N0hIgAjGD1Rn0aQ8kpLBBsImk+Aoh7YFhnvXRhCNkp9N8BuXTfC/uMdMshcWa1OFik/udyjdQM3EJA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.3.tgz",
-      "integrity": "sha512-jsCnclEsR2sV9aHMuaLA5gvxSa0xV4Sc6IJCJ81NTTdb/A5fFbteFBbhuISGF9YoFW1pwbpjuTA6+efXwvLwNQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "dependencies": {
-        "@sentry/types": "6.14.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -1015,9 +1016,9 @@
       "integrity": "sha512-cMRXVxb+NMb6EekKel1fPBfz2ZqE5cGhIS14G7FVUM4Bqilx0lHKnZbsDLWLSeckDpkvlp5six2F7UWyEEJSoQ=="
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1395,6 +1396,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -1449,6 +1461,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -1482,6 +1499,20 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   },
@@ -2197,14 +2228,14 @@
       }
     },
     "@sentry/core": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.14.3.tgz",
-      "integrity": "sha512-3yHmYZzkXlOqPi/CGlNhb2RzXFvYAryBhrMJV26KJ9ULJF8r4OJ7TcWlupDooGk6Knmq8GQML58OApUvYi8IKg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.15.0.tgz",
+      "integrity": "sha512-mCbKyqvD1G3Re6gv6N8tRkBz84gvVWDfLtC6d1WBArIopzter6ktEbvq0cMT6EOvGI2OLXuJ6mtHA93/Q0gGpw==",
       "requires": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/minimal": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -2216,12 +2247,12 @@
       }
     },
     "@sentry/hub": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.14.3.tgz",
-      "integrity": "sha512-ZRWLHcAcv4oZAbpSwvCkXlaa1rVFDxcb9lxo5/5v5n6qJq2IG5Z+bXuT2DZlIHQmuCuqRnFSwuBjmBXY7OTHaw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.15.0.tgz",
+      "integrity": "sha512-cUbHPeG6kKpGBaEMgbTWeU03Y1Up5T3urGF+cgtrn80PmPYYSUPvVvWlZQWPb8CJZ1yQ0gySWo5RUTatBFrEHA==",
       "requires": {
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -2233,12 +2264,12 @@
       }
     },
     "@sentry/minimal": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.14.3.tgz",
-      "integrity": "sha512-2KNOJuhBpMICoOgdxX56UcO9vGdxCw5mNGYdWvJdKrMwRQr7mC+Fc9lTuTbrYTj6zkfklj2lbdDc3j44Rg787A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.15.0.tgz",
+      "integrity": "sha512-7RJIvZsjBa1qFUfMrAzQsWdfZT6Gm4t6ZTYfkpsXPBA35hkzglKbBrhhsUvkxGIhUGw/PiCUqxBUjcmzQP0vfg==",
       "requires": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/types": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -2250,15 +2281,15 @@
       }
     },
     "@sentry/node": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.14.3.tgz",
-      "integrity": "sha512-b7NjMdqpDOTxV0hiR90jlK52i9cTdAJgGjQykGFyBDf7rTGDohyEYsERgJ5+/VC3Inan/P3m12PctWA/TMwZCw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.15.0.tgz",
+      "integrity": "sha512-V1GeupWi9ClmoMy5eBWdVTv3k+Yx/JpddT4zCzzYY9QfjYtEvQI7R3SWFtlgXuaQQaZNU0WUoE2UgJV2N/vS8g==",
       "requires": {
-        "@sentry/core": "6.14.3",
-        "@sentry/hub": "6.14.3",
-        "@sentry/tracing": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/core": "6.15.0",
+        "@sentry/hub": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -2273,15 +2304,15 @@
       }
     },
     "@sentry/serverless": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.14.3.tgz",
-      "integrity": "sha512-RFksAbOiiaaB0n+7mpxQ1MEji1iqmoAxnNS9mNVkyfls6W5iZ9PoNdtkGFFewYaIAhOrAtWTz9sI5NogTk6YVQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-6.15.0.tgz",
+      "integrity": "sha512-FAIS9H5YLxjhn7deLdEJ6lwoGfDpUMbbHP4+9pHe0vIqJ7q7hX4/pjb9IQUu/Hwh62kRI4ORXsmj9KvxAlqmkg==",
       "requires": {
-        "@sentry/minimal": "6.14.3",
-        "@sentry/node": "6.14.3",
-        "@sentry/tracing": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/node": "6.15.0",
+        "@sentry/tracing": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "@types/aws-lambda": "^8.10.62",
         "@types/express": "^4.17.2",
         "tslib": "^1.9.3"
@@ -2295,14 +2326,14 @@
       }
     },
     "@sentry/tracing": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.14.3.tgz",
-      "integrity": "sha512-laFayAxpO/dQL3K3ZcSjtaqJkSf70DH1hHJ8Oiiic0c/xBxh38WSx8yu3TMrbfka5MVIuMNlkq1Gi+SC+moe4w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.15.0.tgz",
+      "integrity": "sha512-V5unvX8qNEfdawX+m2n0jKgmH/YR2ItWZLH+3UevBTptO+xyfvRtpgGXYWUCo3iGvFgWb1C+iIC7LViR9rTvBg==",
       "requires": {
-        "@sentry/hub": "6.14.3",
-        "@sentry/minimal": "6.14.3",
-        "@sentry/types": "6.14.3",
-        "@sentry/utils": "6.14.3",
+        "@sentry/hub": "6.15.0",
+        "@sentry/minimal": "6.15.0",
+        "@sentry/types": "6.15.0",
+        "@sentry/utils": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -2314,16 +2345,16 @@
       }
     },
     "@sentry/types": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.14.3.tgz",
-      "integrity": "sha512-GuyqvjQ/N0hIgAjGD1Rn0aQ8kpLBBsImk+Aoh7YFhnvXRhCNkp9N8BuXTfC/uMdMshcWa1OFik/udyjdQM3EJA=="
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.15.0.tgz",
+      "integrity": "sha512-zBw5gPUsofXUSpS3ZAXqRNedLRBvirl3sqkj2Lez7X2EkKRgn5D8m9fQIrig/X3TsKcXUpijDW5Buk5zeCVzJA=="
     },
     "@sentry/utils": {
-      "version": "6.14.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.14.3.tgz",
-      "integrity": "sha512-jsCnclEsR2sV9aHMuaLA5gvxSa0xV4Sc6IJCJ81NTTdb/A5fFbteFBbhuISGF9YoFW1pwbpjuTA6+efXwvLwNQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.15.0.tgz",
+      "integrity": "sha512-gnhKKyFtnNmKWjDizo7VKD0/Vx8cgW1lCusM6WI7jy2jlO3bQA0+Dzgmr4mIReZ74mq4VpOd2Vfrx7ZldW1DMw==",
       "requires": {
-        "@sentry/types": "6.14.3",
+        "@sentry/types": "6.15.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
@@ -2340,9 +2371,9 @@
       "integrity": "sha512-cMRXVxb+NMb6EekKel1fPBfz2ZqE5cGhIS14G7FVUM4Bqilx0lHKnZbsDLWLSeckDpkvlp5six2F7UWyEEJSoQ=="
     },
     "@types/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -2645,6 +2676,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -2686,6 +2725,11 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -2707,6 +2751,20 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/sqs_lambda/package.json
+++ b/sqs_lambda/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.41.0",
-    "@sentry/serverless": "^6.14.3"
+    "@sentry/serverless": "^6.15.0",
+    "node-fetch": "^2.6.6"
   }
 }

--- a/sqs_lambda/tsconfig.json
+++ b/sqs_lambda/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "target": "es2019",
     "module": "commonjs",
     "outDir": "./dist",
     "sourceMap": true


### PR DESCRIPTION
## Goal
Given a record in our FxA webhook event SQS queue, create a Lambda handler function to make the appropriate request to client-api to handle the event. The function can handle more than one record at a time.

I tested the graphql mutation syntax locally with a local client-api + user-api deployment. Otherwise the function is covered with unit tests that have a mocked response from client-api. I'm not sure exactly what to do regarding robust automated integration testing for this kind of service.

**Changes**
- Add behavior to handle `user_delete` event in queue

## I'd love feedback/perspectives on:
- See below?

## Implementation Decisions
- Didn't do any additional logging/handling regarding user profile update events, which might make it into our queue but won't be processed. Still out of scope? We should consider this before we register our endpoint with FxA.
- Marked TODO where auth needs to be added; all requests will fail at this time

## References

JIRA ticket:
* [INFRA-159]


[INFRA-159]: https://getpocket.atlassian.net/browse/INFRA-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ