### PR TITLE
Infra 231/bugfix sqs endpoint

### DIFF
--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -44,6 +44,7 @@ mutation deleteUser($id: ID!) {
  * the appropriate request against client-api.
  */
 export async function handlerFn(event: { Records: SqsEvent[] }) {
+  console.log(`Event: ${JSON.stringify(event)}`);
   await Promise.all(
     event.Records.map(async (record: SqsEvent) => {
       if (record.event === EVENT.USER_DELETE) {

--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -3,6 +3,7 @@ import config from './config';
 import fetch from 'node-fetch';
 import { getFxaPrivateKey } from './secretManager';
 import { generateJwt } from './jwt';
+import { SQSEvent } from 'aws-lambda';
 
 // Not DRY -- try lambda layers?
 export enum EVENT {
@@ -10,7 +11,7 @@ export enum EVENT {
   PROFILE_UPDATE = 'profile_update',
 }
 
-type SqsEvent = {
+type FxaEvent = {
   user_id: string;
   event: EVENT;
   timestamp: number;
@@ -43,17 +44,22 @@ mutation deleteUser($id: ID!) {
  * Takes records from SQS queue with events, and makes
  * the appropriate request against client-api.
  */
-export async function handlerFn(event: { Records: SqsEvent[] }) {
-  console.log(`Event: ${JSON.stringify(event)}`);
+export async function handlerFn(event: SQSEvent) {
   await Promise.all(
-    event.Records.map(async (record: SqsEvent) => {
-      if (record.event === EVENT.USER_DELETE) {
-        const res = await submitDeleteMutation(record.user_id);
+    event.Records.map(async (record) => {
+      const fxaEvent = JSON.parse(record.body) as FxaEvent;
+      if (!fxaEvent.event || !fxaEvent.user_id) {
+        throw new Error(
+          `Malformed event - missing either 'event' or 'user_id': \n${JSON.stringify(
+            fxaEvent
+          )}`
+        );
+      }
+      if (fxaEvent.event === EVENT.USER_DELETE) {
+        const res = await submitDeleteMutation(fxaEvent.user_id);
         if (res?.errors) {
           throw new Error(
-            `Error processing ${JSON.stringify(record)}: \n${JSON.stringify(
-              res?.errors
-            )}`
+            `Error processing ${record.body}: \n${JSON.stringify(res?.errors)}`
           );
         }
       }


### PR DESCRIPTION
## Goal
Previously the SQS event handler Lambda assumed an improper format for SQS event records. This update fixes that.

Tested in dev

- Use Lambda types for the SQS handler function Lambda
- Investigate SQS type
- Update unit tests for proper format

JIRA ticket:
* [INFRA-231]

[INFRA-231]: https://getpocket.atlassian.net/browse/INFRA-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ