### PR TITLE
fix(fxa-events): Hold on sending SQS messages for any events

### DIFF
--- a/gateway_lambda/config.ts
+++ b/gateway_lambda/config.ts
@@ -23,12 +23,13 @@ const config = {
   fxa: {
     // Represents a map of FxA event schemas and their corresponding events on Pocket
     // FxA events source: https://github.com/mozilla/fxa/blob/main/packages/fxa-event-broker/README.md
-    allowedEvents: {
-      'https://schemas.accounts.firefox.com/event/profile-change':
-        EVENT.PROFILE_UPDATE,
-      'https://schemas.accounts.firefox.com/event/delete-user':
-        EVENT.USER_DELETE,
-    },
+    // TODO: ADD BACK THE EVENTS AFTER JANUARY 18 2022
+    allowedEvents: {},
+    //   'https://schemas.accounts.firefox.com/event/profile-change':
+    //     EVENT.PROFILE_UPDATE,
+    //   'https://schemas.accounts.firefox.com/event/delete-user':
+    //     EVENT.USER_DELETE,
+    // },
   },
 };
 

--- a/gateway_lambda/index.functional.ts
+++ b/gateway_lambda/index.functional.ts
@@ -82,7 +82,8 @@ async function getSqsMessages(): Promise<any[]> {
   return response.Messages;
 }
 
-describe('API Gateway successful event handler', () => {
+// TODO: UNSKIP AFTER 18 JANUARY 2022
+describe.skip('API Gateway successful event handler', () => {
   let clock;
   const now = Date.now();
   let sqsSpy: any;

--- a/gateway_lambda/index.spec.ts
+++ b/gateway_lambda/index.spec.ts
@@ -7,7 +7,8 @@ import {
 } from './index';
 import { EVENT, SqsEvent } from './types';
 
-describe('Handler functions', () => {
+// TODO: UN-SKIP THESE TESTS AFTER JANUARY 18 2022
+describe.skip('Handler functions', () => {
   describe('Format of API Gateway response', () => {
     it('should format a successful response in a standard way', () => {
       const statusCode = 200;


### PR DESCRIPTION
Don't actually put any messages into the queue until January 18 2022.

Made TODOs to update on Jan 18.

See [thread](https://pocket.slack.com/archives/C022HUNDWTB/p1641595663076100)
