### PR TITLE
chore(enable-deletion-events): [INFRA-1003] enable fxa acct deletion event processing

### DIFF
--- a/gateway_lambda/config.ts
+++ b/gateway_lambda/config.ts
@@ -23,13 +23,12 @@ const config = {
   fxa: {
     // Represents a map of FxA event schemas and their corresponding events on Pocket
     // FxA events source: https://github.com/mozilla/fxa/blob/main/packages/fxa-event-broker/README.md
-    // TODO: ADD BACK THE EVENTS AFTER JANUARY 18 2022
-    allowedEvents: {},
-    //   'https://schemas.accounts.firefox.com/event/profile-change':
-    //     EVENT.PROFILE_UPDATE,
-    //   'https://schemas.accounts.firefox.com/event/delete-user':
-    //     EVENT.USER_DELETE,
-    // },
+    allowedEvents: {
+      'https://schemas.accounts.firefox.com/event/profile-change':
+        EVENT.PROFILE_UPDATE,
+      'https://schemas.accounts.firefox.com/event/delete-user':
+        EVENT.USER_DELETE,
+    },
   },
 };
 

--- a/gateway_lambda/index.functional.ts
+++ b/gateway_lambda/index.functional.ts
@@ -82,8 +82,7 @@ async function getSqsMessages(): Promise<any[]> {
   return response.Messages;
 }
 
-// TODO: UNSKIP AFTER 18 JANUARY 2022
-describe.skip('API Gateway successful event handler', () => {
+describe('API Gateway successful event handler', () => {
   let clock;
   const now = Date.now();
   let sqsSpy: any;

--- a/gateway_lambda/index.spec.ts
+++ b/gateway_lambda/index.spec.ts
@@ -7,8 +7,7 @@ import {
 } from './index';
 import { EVENT, SqsEvent } from './types';
 
-// TODO: UN-SKIP THESE TESTS AFTER JANUARY 18 2022
-describe.skip('Handler functions', () => {
+describe('Handler functions', () => {
   describe('Format of API Gateway response', () => {
     it('should format a successful response in a standard way', () => {
       const statusCode = 200;


### PR DESCRIPTION
This got missed somewhere along the line. Listen for and process fxa account deletion events.

## Goal
Enable fxa account deletion event listening. This will result in pocket accounts being deleted if the corresponding fxa account is deleted.

## I'd love feedback/perspectives on:
n/a

## Implementation Decisions
n/a

## Deployment steps
It might be good to validate this works after it is deployed. I will work with Amber after to determine if she thinks it is necessary. There likely isn't a reasonable way to pre-validate this.

## References

JIRA ticket:
https://getpocket.atlassian.net/browse/INFRA-1003

