### PR TITLE
fix(id): Fix incorrect id variable being sent for update email mutation

### DIFF
--- a/sqs_lambda/index.spec.ts
+++ b/sqs_lambda/index.spec.ts
@@ -61,12 +61,7 @@ describe('SQS Event Handler', () => {
   });
 
   it('throws an error if error data is returned from client-api for profile update event', async () => {
-    // this error is thrown in the submitEmailUpdatedMutation function on the failed client-api fetch request
-    const clientApiRequestError = `Error occurred while requesting client-api: \n${JSON.stringify(
-      'SomeClientApiError'
-    )}`;
-
-    const replyData = { data: null, errors: { clientApiRequestError } };
+    const replyData = { data: null, errors: { CODE: 'BADREQUEST' } };
     const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
     const record = {
       user_id: '12345',
@@ -87,7 +82,7 @@ describe('SQS Event Handler', () => {
     expect(scope.isDone()).toBeTruthy();
   });
 
-  it('throws an error if error data is returned from client-api', async () => {
+  it('throws an error if error data is returned from client-api for user delete event', async () => {
     const replyData = { data: null, errors: { CODE: 'FORBIDDEN' } };
     const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
     const record = {

--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -78,13 +78,7 @@ async function submitEmailUpdatedMutation(
       Authorization: `Bearer ${generateJwt(privateKey, id)}`,
     },
     body: JSON.stringify({ query: updateUserEmailMutation, variables }),
-  })
-    .then((response) => response.json())
-    .catch((error) => {
-      throw new Error(
-        `Error occurred while requesting client-api: \n${JSON.stringify(error)}`
-      );
-    });
+  }).then((response) => response.json());
 }
 
 /**

--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -65,7 +65,7 @@ async function submitEmailUpdatedMutation(
 ): Promise<any> {
   const privateKey = await getFxaPrivateKey();
 
-  const updateUserEmailMutation = `mutation UpdateUserEmailByFxaId($fxaId: ID!, $email: String!) {updateUserEmailByFxaId(id: $fxaId, email: $email) {
+  const updateUserEmailMutation = `mutation UpdateUserEmailByFxaId($id: ID!, $email: String!) {updateUserEmailByFxaId(id: $id, email: $email) {
     email
   }
 }`;
@@ -78,7 +78,13 @@ async function submitEmailUpdatedMutation(
       Authorization: `Bearer ${generateJwt(privateKey, id)}`,
     },
     body: JSON.stringify({ query: updateUserEmailMutation, variables }),
-  }).then((response) => response.json());
+  })
+    .then((response) => response.json())
+    .catch((error) => {
+      throw new Error(
+        `Error occurred while requesting client-api: \n${JSON.stringify(error)}`
+      );
+    });
 }
 
 /**


### PR DESCRIPTION
## Goal
Fix for this PR:https://github.com/Pocket/fxa-webhook-proxy/pull/731.

It was sending incorrect mutation variables:
`{fxaId: id, email: email}` instead of 
`{id: id, email: email}`