### PR TITLE
fix incorrect client api uri

### DIFF
--- a/sqs_lambda/config.ts
+++ b/sqs_lambda/config.ts
@@ -23,7 +23,7 @@ const config = {
   },
   clientApiUri: isDev
     ? process.env.CLIENT_API_URI || 'https://client-api.getpocket.dev'
-    : process.env.CLIENT_API_URI || 'https://client-api.readitlater.com',
+    : process.env.CLIENT_API_URI || 'https://client-api.getpocket.com',
 };
 
 export default config;


### PR DESCRIPTION
## Goal
The fetch request is returning a `404` but when using the `getpocket.com` endpoint, we do seem to get a proper response. However, we still might run into another expected `jwt` error but that will be addressed in a follow up PR.