### PR TITLE
fix(validateIssuer): [INFRA-1280] Validate issuer uri for jwk extraction

### DIFF
--- a/gateway_lambda/config.ts
+++ b/gateway_lambda/config.ts
@@ -29,6 +29,14 @@ const config = {
       'https://schemas.accounts.firefox.com/event/delete-user':
         EVENT.USER_DELETE,
     },
+    // These should not change unless explicitly communicated by the FxA team
+    // source: "https://accounts.firefox.com/.well-known/openid-configuration"
+    issuer: 'https://accounts.firefox.com',
+
+    // This should always be "https://accounts.firefox.com/.well-known/openid-configuration"
+    // unless a different URI is explicitly communicated by the FxA team
+    openIdConfigUrl:
+      'https://accounts.firefox.com/.well-known/openid-configuration',
   },
 };
 

--- a/gateway_lambda/jwt.spec.ts
+++ b/gateway_lambda/jwt.spec.ts
@@ -7,29 +7,36 @@ describe('jwt', () => {
   const publicKey = fs.readFileSync(__dirname + '/test/jwtRS256.key.pub', {
     encoding: 'ascii',
   }) as string;
+
   const privateKey = fs.readFileSync(__dirname + '/test/jwtRS256.key', {
     encoding: 'ascii',
   }) as string;
+
   const otherPrivateKey = fs.readFileSync(
     __dirname + '/test/private-other.key',
     {
       encoding: 'ascii',
     }
   ) as string;
-  describe('validate', () => {
+
+  describe('validate method', () => {
     let getPublicJwkStub;
+
     beforeAll(() => {
       getPublicJwkStub = sinon.stub(FxaJwt.prototype, 'getPublicJwk');
       getPublicJwkStub.resolves(publicKey);
     });
+
     afterAll(() => {
       getPublicJwkStub.restore();
     });
+
     it('should throw an error if jwt could not be decoded', async () => {
       await expect(async () => {
         await new FxaJwt('abc123imnotarealjwt').validate();
       }).rejects.toThrow('Token could not be decoded.');
     });
+
     it('should throw an error if jwt was not signed by expected key', async () => {
       const token = jwt.sign({ hello: 'world' }, otherPrivateKey, {
         algorithm: 'RS256',
@@ -38,6 +45,7 @@ describe('jwt', () => {
         await new FxaJwt(token).validate();
       }).rejects.toThrow();
     });
+
     it('should throw an error if payload did not contain `sub`', async () => {
       const token = jwt.sign({ events: { crew: 'olympics' } }, privateKey, {
         algorithm: 'RS256',
@@ -46,6 +54,7 @@ describe('jwt', () => {
         await new FxaJwt(token).validate();
       }).rejects.toThrow('Invalid token format: ');
     });
+
     it('should throw an error if payload did not contain `events`', async () => {
       const token = jwt.sign({ sub: 'plamen' }, privateKey, {
         algorithm: 'RS256',
@@ -54,6 +63,7 @@ describe('jwt', () => {
         await new FxaJwt(token).validate();
       }).rejects.toThrow('Invalid token format: ');
     });
+
     it('should throw an error if payload events are empty', async () => {
       const token = jwt.sign({ sub: 'plamen', events: {} }, privateKey, {
         algorithm: 'RS256',
@@ -62,6 +72,7 @@ describe('jwt', () => {
         await new FxaJwt(token).validate();
       }).rejects.toThrow('Invalid token format: ');
     });
+
     it('should return a payload', async () => {
       const payload = { sub: 'plamen', events: { crew: 'olympics' } };
 
@@ -70,6 +81,53 @@ describe('jwt', () => {
       });
       const result = await new FxaJwt(token).validate();
       expect(result).toEqual(expect.objectContaining(payload));
+    });
+  });
+
+  describe('getPublicJwk method', () => {
+    it('should throw an error if the token payload does not have the iss property', async () => {
+      const invalidTokenPayload = {
+        payload: {
+          sub: 'plamen',
+          events: { crew: 'olympics' },
+          //missing iss property
+        },
+      };
+
+      // stubbing the jwt.decode function in the constructor to return the incorrect
+      // token payload object which the class variable 'token' is set to
+      const jwtDecodeStub = sinon
+        .stub(jwt, 'decode')
+        .returns(invalidTokenPayload);
+
+      await expect(async () => {
+        await new FxaJwt('test-token').getPublicJwk();
+      }).rejects.toThrow('Invalid token: No token issuer or incorrect issuer.');
+
+      jwtDecodeStub.restore();
+    });
+
+    it('should throw an error if the token payload iss property does not match the one in config', async () => {
+      const invalidTokenPayload = {
+        payload: {
+          sub: 'plamen',
+          events: { crew: 'olympics' },
+          iss: 'test.accounts.google.com', //does not match config.fxa.endpoints.issuer
+        },
+      };
+
+      // stubbing the jwt.decode function in the constructor to return the incorrect
+      // token payload object which the class variable 'token' is set to
+      const jwtDecodeStub = sinon
+        .stub(jwt, 'decode')
+        .returns(invalidTokenPayload);
+
+      await expect(async () => {
+        // instantiate FxaJwt class instance with its 'token' variable set incorrectly
+        await new FxaJwt('test-token').getPublicJwk();
+      }).rejects.toThrow('Invalid token: No token issuer or incorrect issuer.');
+
+      jwtDecodeStub.restore();
     });
   });
 });

--- a/gateway_lambda/jwt.ts
+++ b/gateway_lambda/jwt.ts
@@ -1,7 +1,8 @@
 import jwt from 'jsonwebtoken';
 import jwksClient from 'jwks-rsa';
 import fetch from 'node-fetch';
-import { FxaPayload } from './types';
+import config from './config';
+import { FxaPayload, FxaOpenIdConfigPayload } from './types';
 
 export class FxaJwt {
   public readonly token: jwt.Jwt;
@@ -20,15 +21,18 @@ export class FxaJwt {
    * Get public JWK from the auth server
    */
   public async getPublicJwk() {
-    if (!this.token.payload.iss) {
-      throw new Error('Invalid token: No token issuer.');
+    if (!this.isValidIssuer(this.token.payload.iss)) {
+      throw new Error('Invalid token: No token issuer or incorrect issuer.');
     }
     if (!this.token.header.kid) {
       throw new Error('Invalid token: No token kid.');
     }
-    const configUrl = `${this.token.payload.iss}/.well-known/openid-configuration`;
-    const config = (await (await fetch(configUrl)).json()) as any;
-    const client = jwksClient({ jwksUri: config.jwks_uri });
+
+    const fxaOpenIdConfigPayload: FxaOpenIdConfigPayload = await (
+      await fetch(config.fxa.openIdConfigUrl)
+    ).json();
+
+    const client = jwksClient({ jwksUri: fxaOpenIdConfigPayload.jwks_uri });
     const key = await client.getSigningKey(this.token.header.kid);
     return key.getPublicKey();
   }
@@ -54,5 +58,15 @@ export class FxaJwt {
     }
     // return the decoded JWT payload
     return payload as FxaPayload;
+  }
+
+  /**
+   * Validate the issuer string. Make sure it's not false-y and matches the issuer uri in config
+   * See bullet #3 here: https://mozilla.github.io/ecosystem-platform/reference/tokens#local-verification-of-a-jwt-access-token
+   * @param issuerUri
+   * @returns
+   */
+  private isValidIssuer(issuerUri?: string) {
+    return issuerUri && issuerUri === config.fxa.issuer;
   }
 }

--- a/gateway_lambda/types.ts
+++ b/gateway_lambda/types.ts
@@ -38,3 +38,24 @@ export type FxaPayload = {
   sub: string;
   events: FxaEvent;
 };
+
+/**
+ * The type below is sourced from: "https://accounts.firefox.com/.well-known/openid-configuration"
+ */
+export type FxaOpenIdConfigPayload = {
+  authorization_endpoint: string;
+  introspection_endpoint: string;
+  issuer: string;
+  jwks_uri: string;
+  revocation_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  verify_endpoint: string;
+
+  claims_supported: string[];
+  id_token_signing_alg_values_supported: string[];
+  response_types_supported: string[];
+  scopes_supported: string[];
+  subject_types_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+};


### PR DESCRIPTION
## Goal
Adding the FxA issuer URI in our config instead of extracting from the jwt payload. 

This URI is very less likely to change in the future. If it does change, it will be a big deal and will be communicated by the FxA team.

See bullet point 3: https://mozilla.github.io/ecosystem-platform/reference/tokens#local-verification-of-a-jwt-access-token 

## I'd love feedback/perspectives on:
Adding comments where I need feedback below

## References

JIRA ticket:
* [INFRA-1280](https://getpocket.atlassian.net/browse/INFRA-1280)