### PR TITLE
fix(sqs): limiting the fxa event processing to 5 concurrency to not overwhelm user api

### DIFF
--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -34,6 +34,7 @@ export class SqsLambda extends Construct {
         runtime: LAMBDA_RUNTIMES.NODEJS14,
         handler: 'index.handler',
         timeout: 120,
+        reservedConcurrencyLimit: 5, // only allow 5 executations at a time in case FxA suddenly sends us a lot of SQS messages
         environment: {
           REGION: vpc.region,
           JWT_KEY: config.sqsLambda.jwtKey,


### PR DESCRIPTION
## Goal

Ensure during normal operations we limit the concurrency on our SQS lambda that hits our downstream api. 

Setting this to 5 for now and we can adjust later.
