### PR TITLE
fix(lambda): updating lambda on FxA webhook to process a bit slower

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -15,8 +15,8 @@ import { AwsProvider } from '@cdktf/provider-aws/lib/provider';
 import { PagerdutyProvider } from '@cdktf/provider-pagerduty/lib/provider';
 import { SqsLambda } from './sqsLambda';
 import { ArchiveProvider } from '@cdktf/provider-archive/lib/provider';
-import { NullProvider } from '@cdktf/provider-null/lib/provider'
-import { LocalProvider } from '@cdktf/provider-local/lib/provider'
+import { NullProvider } from '@cdktf/provider-null/lib/provider';
+import { LocalProvider } from '@cdktf/provider-local/lib/provider';
 import { ApiGateway } from './apiGateway';
 
 class FxAWebhookProxy extends TerraformStack {
@@ -42,6 +42,7 @@ class FxAWebhookProxy extends TerraformStack {
       name: `${config.prefix}-Queue`,
       maxReceiveCount: 3,
       visibilityTimeoutSeconds: 300,
+      messageRetentionSeconds: 604800, // Set retention to 7 days in case we get a lot of events to process.. unlikely, but safer.
     });
 
     new SqsLambda(this, 'proxy-lambda', vpc, sqs.sqsQueue, pagerDuty);
@@ -72,12 +73,12 @@ class FxAWebhookProxy extends TerraformStack {
     return new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
-        criticalEscalationPolicyId: incidentManagement.get(
-          'policy_backend_critical_id'
-        ).toString(),
-        nonCriticalEscalationPolicyId: incidentManagement.get(
-          'policy_backend_non_critical_id'
-        ).toString(),
+        criticalEscalationPolicyId: incidentManagement
+          .get('policy_backend_critical_id')
+          .toString(),
+        nonCriticalEscalationPolicyId: incidentManagement
+          .get('policy_backend_non_critical_id')
+          .toString(),
       },
     });
   }

--- a/.aws/src/sqsLambda.ts
+++ b/.aws/src/sqsLambda.ts
@@ -25,7 +25,7 @@ export class SqsLambda extends Construct {
     new PocketSQSWithLambdaTarget(this, 'fxa-events-sqs-lambda', {
       name: `${config.prefix}-Sqs-FxA-Events`,
       // set batchSize to something reasonable
-      batchSize: 25,
+      batchSize: 1, // Setting batch size to one so we can control concurreny easily until we get logging and errors a little clearer.
       batchWindow: 60,
       configFromPreexistingSqsQueue: {
         name: sqsQueue.name,
@@ -34,7 +34,7 @@ export class SqsLambda extends Construct {
         runtime: LAMBDA_RUNTIMES.NODEJS14,
         handler: 'index.handler',
         timeout: 120,
-        reservedConcurrencyLimit: 5, // only allow 5 executations at a time in case FxA suddenly sends us a lot of SQS messages
+        reservedConcurrencyLimit: 10, // only allow 10 executations at a time in case FxA suddenly sends us a lot of SQS messages
         environment: {
           REGION: vpc.region,
           JWT_KEY: config.sqsLambda.jwtKey,


### PR DESCRIPTION
## Goal

The sqs event lambda was processing at a very fast rate which could cause some strain to user-api which is generally scaled at low volume due to its traffic. If FxA suddenly sent us a lot of events it would then cause this lambda to hit our API with a thundering herd.

Combine that with logging that needs to be cleaned up, it is safer and easier to follow if we lower the volume of the FxA webhook lambda for now.

I also think the entry point should be returning the `Promise.all` but unclear.

## I'd love feedback/perspectives on:
- Anyone disagree?
- Is this a good rate?
