### PR TITLE
fix(lambda): make the FxA lambda not throw on not found errors

### DIFF
--- a/sqs_lambda/index.spec.ts
+++ b/sqs_lambda/index.spec.ts
@@ -161,6 +161,22 @@ describe('SQS Event Handler', () => {
     expect(scope.isDone()).toBeTruthy();
   });
 
+  it('returns success if a NotFoundError is returned from client-api for profile update event', async () => {
+    const replyData = { data: null, errors: { CODE: 'NOT_FOUND' } };
+    const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
+    const record = {
+      user_id: '12345',
+      event: fx.EVENT.PROFILE_UPDATE,
+      timestamp: 12345,
+      user_email: 'example@test.com',
+    };
+    const res = await fx.handlerFn({
+      Records: [{ body: JSON.stringify(record) }],
+    } as any);
+    expect(res).toStrictEqual({});
+    // Nock marks as done if a request was successfully intercepted
+    expect(scope.isDone()).toBeTruthy();
+  });
   it('throws an error if error data is returned from client-api for user delete event', async () => {
     const replyData = { data: null, errors: { CODE: 'FORBIDDEN' } };
     const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
@@ -178,6 +194,21 @@ describe('SQS Event Handler', () => {
         replyData.errors
       )}`
     );
+    // Nock marks as done if a request was successfully intercepted
+    expect(scope.isDone()).toBeTruthy();
+  });
+  it('returns success if a NotFoundError is returned from client-api for user delete event', async () => {
+    const replyData = { data: null, errors: { CODE: 'NOT_FOUND' } };
+    const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
+    const record = {
+      user_id: '12345',
+      event: fx.EVENT.USER_DELETE,
+      timestamp: 12345,
+    };
+    const res = await fx.handlerFn({
+      Records: [{ body: JSON.stringify(record) }],
+    } as any);
+    expect(res).toStrictEqual({});
     // Nock marks as done if a request was successfully intercepted
     expect(scope.isDone()).toBeTruthy();
   });

--- a/sqs_lambda/index.ts
+++ b/sqs_lambda/index.ts
@@ -135,9 +135,18 @@ export async function handlerFn(event: SQSEvent) {
       if (fxaEvent.event === EVENT.USER_DELETE) {
         const res = await submitDeleteMutation(fxaEvent.user_id);
         if (res?.errors) {
-          throw new Error(
-            `Error processing ${record.body}: \n${JSON.stringify(res?.errors)}`
-          );
+          if (res.errors.CODE && res.errors.CODE == 'NOT_FOUND') {
+            console.info('FxA User not found', {
+              userId: fxaEvent.user_id,
+              event: fxaEvent,
+            });
+          } else {
+            throw new Error(
+              `Error processing ${record.body}: \n${JSON.stringify(
+                res?.errors
+              )}`
+            );
+          }
         }
       }
 
@@ -160,9 +169,18 @@ export async function handlerFn(event: SQSEvent) {
           fxaEvent.transfer_sub
         );
         if (res?.errors) {
-          throw new Error(
-            `Error processing ${record.body}: \n${JSON.stringify(res?.errors)}`
-          );
+          if (res.errors.CODE && res.errors.CODE == 'NOT_FOUND') {
+            console.info('FxA User not found', {
+              userId: fxaEvent.user_id,
+              event: fxaEvent,
+            });
+          } else {
+            throw new Error(
+              `Error processing ${record.body}: \n${JSON.stringify(
+                res?.errors
+              )}`
+            );
+          }
         }
       }
 
@@ -179,9 +197,18 @@ export async function handlerFn(event: SQSEvent) {
         );
 
         if (res?.errors) {
-          throw new Error(
-            `Error processing ${record.body}: \n${JSON.stringify(res?.errors)}`
-          );
+          if (res.errors.CODE && res.errors.CODE == 'NOT_FOUND') {
+            console.info('FxA User not found', {
+              userId: fxaEvent.user_id,
+              event: fxaEvent,
+            });
+          } else {
+            throw new Error(
+              `Error processing ${record.body}: \n${JSON.stringify(
+                res?.errors
+              )}`
+            );
+          }
         }
       }
     })


### PR DESCRIPTION
## Goal

There are a bunch of users that deleted their Pocket account, but retained their FxA account, however we still receive FxA webhook callbacks for the deleted users. 

In this event user-api will return a NotFound error and we should mark the SQS message as successful, before we were marking this as a failure.

This should stop the errors like https://pocket.sentry.io/issues/4224409867/?project=6055107&query=is%3Aunresolved&referrer=issue-stream&stream_index=0

## I'd love feedback/perspectives on:
- Is this the right way to check for errors?

## Implementation Decisions
- 

## Deployment steps
- [ ] Database migrations?
- [ ] Secrets?
- [ ] **FOR POCKET DEVELOPERS ONLY** - Post in [\#changelog](https://pocket.slack.com/archives/C0Q4UFMDZ):
> Write a #changelog message using our [best practices](https://docs.google.com/document/d/1oEt8Mtkp-6Xz9S2zaNX1EIXfQIEDN2JpY0diuPc1HZc/edit) if this PR (potentially) impacts users. Describe the 'why' and 'what'. @mention relevant teams. Link to this PR.

## References

JIRA ticket:
* Link to JIRA ticket

Issue:
* Link to GitHub issue

Documentation:
* Project doc
