### PR TITLE
chore(pagerduty):  [SOCIALPLAT-700] Remove this service from Tier 1 PagerDuty policy

### DIFF
--- a/.aws/src/main.ts
+++ b/.aws/src/main.ts
@@ -73,8 +73,9 @@ class FxAWebhookProxy extends TerraformStack {
     return new PocketPagerDuty(this, 'pagerduty', {
       prefix: config.prefix,
       service: {
+        // This is a Tier 2 service and as such only raises non-critical alarms.
         criticalEscalationPolicyId: incidentManagement
-          .get('policy_default_critical_id')
+          .get('policy_default_non_critical_id')
           .toString(),
         nonCriticalEscalationPolicyId: incidentManagement
           .get('policy_default_non_critical_id')


### PR DESCRIPTION
## Goal
 
Remove this service from Tier 1 PagerDuty policy.

Note: no alarms are actually set as of now. TODOs in the code suggest appropriate alarm metrics are yet to be determined. 

## References

JIRA ticket:
* https://mozilla-hub.atlassian.net/browse/SOCIALPLAT-700