### PR TITLE
fix(jwt): jwt should be snakecase

### DIFF
--- a/sqs_lambda/jwt.ts
+++ b/sqs_lambda/jwt.ts
@@ -8,7 +8,7 @@ type JwtPayload = {
   iat: number; //timestamp
   exp: number;
   sub: string;
-  apiId?: string;
+  api_id?: string;
 };
 
 /**
@@ -26,7 +26,7 @@ export function generateJwt(privateKey, fxaId: string) {
     iat: now,
     exp: now + 60 * 10, //expires in 10 mins
     sub: fxaId,
-    apiId: config.app.apiId,
+    api_id: config.app.apiId,
   };
 
   return jwt.sign(payload, jwkToPem(privateKey, { private: true }), {


### PR DESCRIPTION
## Goal

In looking at something else, I noticed that client API expects a snake case based api_id in the jwt https://github.com/Pocket/client-api/blob/main/src/jwtUtils.ts#L167