### PR TITLE
fix(error handling): fix a bug where missing FxA user was reported as 500 error

### DIFF
--- a/sqs_lambda/index.spec.ts
+++ b/sqs_lambda/index.spec.ts
@@ -150,7 +150,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('throws an error if error data is returned from client-api for apple migration event', async () => {
-      const replyData = { data: null, errors: { CODE: 'BADREQUEST' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'BADREQUEST' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -205,7 +208,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('throws an error if error data is returned from client-api when expiring a web session', async () => {
-      const replyData = { data: null, errors: { CODE: 'FORBIDDEN' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'FORBIDDEN' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -232,7 +238,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('returns success if a NotFoundError is returned from client-api when expiring a web session', async () => {
-      const replyData = { data: null, errors: { CODE: 'NOT_FOUND' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'NOT_FOUND' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -287,7 +296,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('throws an error if error data is returned from client-api for profile update event', async () => {
-      const replyData = { data: null, errors: { CODE: 'BADREQUEST' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'BADREQUEST' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -315,7 +327,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('returns success if a NotFoundError is returned from client-api for profile update event', async () => {
-      const replyData = { data: null, errors: { CODE: 'NOT_FOUND' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'NOT_FOUND' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -368,7 +383,10 @@ describe('SQS Event Handler', () => {
     });
 
     it('throws an error if error data is returned from client-api for user delete event', async () => {
-      const replyData = { data: null, errors: { CODE: 'FORBIDDEN' } };
+      const replyData = {
+        data: null,
+        errors: [{ extensions: { code: 'FORBIDDEN' } }],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {
@@ -395,7 +413,19 @@ describe('SQS Event Handler', () => {
     });
 
     it('returns success if a NotFoundError is returned from client-api for user delete event', async () => {
-      const replyData = { data: null, errors: { CODE: 'NOT_FOUND' } };
+      // Temporarily just fix this test data until we use a typed client
+      // Pulled from a real log
+      const replyData = {
+        data: null,
+        errors: [
+          {
+            message: 'Error - Not Found: FxA user not found',
+            extensions: {
+              code: 'NOT_FOUND',
+            },
+          },
+        ],
+      };
       const scope = nock(config.clientApiUri).post('/').reply(200, replyData);
 
       const record = {

--- a/sqs_lambda/mutations.ts
+++ b/sqs_lambda/mutations.ts
@@ -26,7 +26,10 @@ export function handleMutationErrors(
   res?: any
 ) {
   if (res?.errors) {
-    if (res.errors.CODE && res.errors.CODE == 'NOT_FOUND') {
+    const hasNotFoundError = res.errors.filter(
+      (error) => error.extensions?.code === 'NOT_FOUND'
+    );
+    if (hasNotFoundError.length) {
       console.info('FxA User not found', {
         userId: fxaEvent.user_id,
         event: fxaEvent,


### PR DESCRIPTION
This is a quick band-aid, but we should eventually use a typed client for making these requests so that we can leverage type-safety for similar issues in the future.

[POCKET-9361]


[POCKET-9361]: https://mozilla-hub.atlassian.net/browse/POCKET-9361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ